### PR TITLE
Update the runtime version from 6.9 to 6.10, and more

### DIFF
--- a/io.github.sockeye_d.godl.yml
+++ b/io.github.sockeye_d.godl.yml
@@ -1,6 +1,6 @@
 id: io.github.sockeye_d.godl
 runtime: org.kde.Platform
-runtime-version: '6.9'
+runtime-version: '6.10'
 sdk: org.kde.Sdk
 command: godl
 finish_args:
@@ -15,15 +15,6 @@ cleanup:
   - "/include"
   - "/lib/cmake"
 modules:
-  - name: kirigami-addons
-    buildsystem: cmake-ninja
-    config-opts:
-      - -DCMAKE_BUILD_TYPE=MinSizeRel
-      - -DBUILD_TESTING=OFF
-    sources:
-      - type: archive
-        url: https://download.kde.org/stable/kirigami-addons/kirigami-addons-1.10.0.tar.xz
-        sha256: c98f92bf7c452e12f6dc403404215413db3959fe904ad830ead0db6bb09b3d11
   - name: godl
     buildsystem: cmake-ninja
     config-opts:


### PR DESCRIPTION
- Update the runtime version to 6.10
- Use the kirigami-addons module from the runtime

Fixes: https://github.com/flathub/io.github.sockeye_d.godl/issues/6 
Fixes: https://github.com/flathub/io.github.sockeye_d.godl/issues/4