### PR TITLE
Update the runtime version from 6.9 to 6.10, and more

### DIFF
--- a/io.github.sockeye_d.godl.yml
+++ b/io.github.sockeye_d.godl.yml
@@ -1,6 +1,6 @@
 id: io.github.sockeye_d.godl
 runtime: org.kde.Platform
-runtime-version: '6.9'
+runtime-version: '6.10'
 sdk: org.kde.Sdk
 command: godl
 finish_args:
@@ -10,26 +10,12 @@ finish_args:
   - --device=dri
   - --share=network
   - --filesystem=host
-cleanup:
-  - "/share/kdevappwizard6"
-  - "/include"
-  - "/lib/cmake"
 modules:
-  - name: kirigami-addons
-    buildsystem: cmake-ninja
-    config-opts:
-      - -DCMAKE_BUILD_TYPE=MinSizeRel
-      - -DBUILD_TESTING=OFF
-    sources:
-      - type: archive
-        url: https://download.kde.org/stable/kirigami-addons/kirigami-addons-1.10.0.tar.xz
-        sha256: c98f92bf7c452e12f6dc403404215413db3959fe904ad830ead0db6bb09b3d11
   - name: godl
     buildsystem: cmake-ninja
     config-opts:
       - -DCMAKE_BUILD_TYPE=MinSizeRel
       - -DBUILD_TESTING=OFF
-      - -DQML_IMPORT_PATH=/app/lib/qt6/qml
     sources:
       - type: git
         url: https://github.com/sockeye-d/godl.git


### PR DESCRIPTION
- Update the runtime version to 6.10
- Drop ineffective cleanup commands
- Use kirigami-addons module from the runtime

**Please don't forget to test before merging.**

---

Error

```bash
Extracting template QFileInfo(:/templates/default)
Extracting template QFileInfo(:/templates/default (Godot 3))
qrc:/org/fishy/godl/ui/RemoteVersionsPage.qml:278:5: 
    QML OverlaySheet: Binding loop detected for property "implicitHeight":
qrc:/qt/qml/org/kde/kirigami/templates/OverlaySheet.qml:139:5

```